### PR TITLE
Optimize Log Printing - Get Cluster

### DIFF
--- a/src/main/java/com/ly/ckibana/configure/config/ProxyConfigLoader.java
+++ b/src/main/java/com/ly/ckibana/configure/config/ProxyConfigLoader.java
@@ -97,6 +97,7 @@ public class ProxyConfigLoader {
         metadataRestClient = requestContext.getProxyConfig().getRestClient();
 
         refreshConfig();
+
         // 初始化proxy-settings 索引
         boolean initSettingsIndex = EsClientUtil.createIndex(metadataRestClient, getSettingsIndexName(),
                 Constants.ConfigFile.SETTINGS_PROPERTIES, Constants.ConfigFile.SETTINGS_INDEX_SHARDS, majorVersion);
@@ -168,8 +169,6 @@ public class ProxyConfigLoader {
         } catch (IndexNotFoundException e) {
             EsClientUtil.createIndex(metadataRestClient, getSettingsIndexName(), Constants.ConfigFile.SETTINGS_PROPERTIES, kibanaProperty.getDefaultShard(), majorVersion);
             initConfig();
-        } catch (Exception e) {
-            log.error("init config from es error. hosts:{}, headers:{}, searchResult:{}", metadataConfigProperty.getHosts(), metadataConfigProperty.getHeaders(), searchResult, e);
         }
     }
 
@@ -211,6 +210,6 @@ public class ProxyConfigLoader {
 
     public String getSettingsIndexName() {
         return Constants.ConfigFile.SETTINGS_INDEX_NAME
-                + (StringUtils.isBlank(metadataConfigProperty.getSettingsSuffix()) ? Strings.EMPTY : String.format("-%s", metadataConfigProperty.getSettingsSuffix()));
+               + (StringUtils.isBlank(metadataConfigProperty.getSettingsSuffix()) ? Strings.EMPTY : String.format("-%s", metadataConfigProperty.getSettingsSuffix()));
     }
 }

--- a/src/main/java/com/ly/ckibana/configure/config/ProxyConfigLoader.java
+++ b/src/main/java/com/ly/ckibana/configure/config/ProxyConfigLoader.java
@@ -169,6 +169,9 @@ public class ProxyConfigLoader {
         } catch (IndexNotFoundException e) {
             EsClientUtil.createIndex(metadataRestClient, getSettingsIndexName(), Constants.ConfigFile.SETTINGS_PROPERTIES, kibanaProperty.getDefaultShard(), majorVersion);
             initConfig();
+        } catch (Exception e) {
+            log.error("init config from es error. hosts:{}, headers:{}, searchResult:{}", metadataConfigProperty.getHosts(), metadataConfigProperty.getHeaders(), searchResult, e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/ly/ckibana/configure/thread/ThreadPoolConfigurer.java
+++ b/src/main/java/com/ly/ckibana/configure/thread/ThreadPoolConfigurer.java
@@ -82,7 +82,13 @@ public class ThreadPoolConfigurer implements Closeable {
         log.info("[thread_pool][common] init successful. {}", msearchConfig);
 
         // init kibana proxy config scheduled task
-        commonScheduledExecutor.scheduleAtFixedRate(() -> proxyConfigLoader.refreshConfig(), 10, 10, TimeUnit.SECONDS);
+        commonScheduledExecutor.scheduleAtFixedRate(() -> {
+            try {
+                proxyConfigLoader.refreshConfig();
+            } catch (Exception e) {
+                log.warn("refresh config error", e);
+            }
+        }, 10, 10, TimeUnit.SECONDS);
         log.info("[task][refresh config] init successful. {}", msearchConfig);
 
         commonExecutor.submit(() -> sqlMonitorService.asyncRecordMonitoring());


### PR DESCRIPTION
## Description
When the cluster is inaccessible, the startup project log prints a majorVersion=null error, which is misleading to users.

## Changes Made
Classify the error in getting the version as a cluster initialization error and don't handle the exception separately.

## Checklist
- [x] Tested locally, no new bugs.
- [x] Followed the project's code style and guidelines.
- [x] Maintained consistency with the rest of the project.
- [x] Updated relevant documentation, such as README, CHANGELOG.