### PR TITLE
fix: The Http status code of the request es should be passed back to kibana

### DIFF
--- a/src/main/java/com/ly/ckibana/service/EsClientUtil.java
+++ b/src/main/java/com/ly/ckibana/service/EsClientUtil.java
@@ -387,5 +387,7 @@ public class EsClientUtil {
                 httpServletResponse.setHeader(esResponseHeader.getName(), esResponseHeader.getValue());
             }
         }
+        // 设置code码
+        httpServletResponse.setStatus(esResponse.getStatusLine().getStatusCode());
     };
 }


### PR DESCRIPTION
# Description
In higher versions of es, e.g. 8.11+, kibana does logical processing of status codes, which is used to generate `ResponseError` objects. The proxy should not return 200 for all requests, e.g. a 404 status code for an index that does not exist.