### PR TITLE
fix: sorted fields are not sorted if they do not exist (except for extended fields)

### DIFF
--- a/src/main/java/com/ly/ckibana/parser/MsearchParamParser.java
+++ b/src/main/java/com/ly/ckibana/parser/MsearchParamParser.java
@@ -72,7 +72,7 @@ public class MsearchParamParser extends ParamParser {
     public void checkTimeInRange(CkRequestContext ckRequestContext) {
         if (!isTimeInRange(ckRequestContext)) {
             throw new TimeNotInRangeException("查询时间跨度太大,目前支持最大查询区间为:"
-                    + DateUtils.formatDurationWords(proxyConfigLoader.getKibanaProperty().getProxy().getMaxTimeRange()));
+                                              + DateUtils.formatDurationWords(proxyConfigLoader.getKibanaProperty().getProxy().getMaxTimeRange()));
         }
     }
 
@@ -142,7 +142,12 @@ public class MsearchParamParser extends ParamParser {
             List<Map> sortArray = JSONUtils.deserializeToList(searchQuery.getString(Constants.SORT), Map.class);
             for (Map<String, Object> each : sortArray) {
                 each.keySet().forEach(orgField -> {
-                    String ckSortFieldName = ParamConvertUtils.convertUiFieldToCkField(ckRequestContext.getColumns(), orgField);
+                    Map<String, String> columns = ckRequestContext.getColumns();
+                    String ckSortFieldName = ParamConvertUtils.convertUiFieldToCkField(columns, orgField);
+                    // 如果该字段在ck中不存在，且无ck_assembly_extension扩展字段，则不放到排序条件中
+                    if (!columns.containsKey(ckSortFieldName) && !columns.containsKey(Constants.CK_EXTENSION)) {
+                        return;
+                    }
                     String ckSortType = StringUtils.upperCase(JSONUtils.convert(each.get(orgField), JSONObject.class).getString("order"));
                     sort.add(String.format("%s %s", ProxyUtils.getFieldSqlPart(ckSortFieldName), ckSortType));
                     sortedFields.add(new SortedField(orgField, ckSortFieldName, SortType.valueOf(ckSortType)));


### PR DESCRIPTION
# Description
sorted fields are not sorted if they do not exist (except for extended fields), eg. _doc