### PR TITLE
feat: 增加check接口，用于排查ck表在index pattern中不显示的问题 #34

### DIFF
--- a/src/main/java/com/ly/ckibana/handlers/CheckHandler.java
+++ b/src/main/java/com/ly/ckibana/handlers/CheckHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 LY.com All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ly.ckibana.handlers;
+
+import com.ly.ckibana.configure.config.ProxyConfigLoader;
+import com.ly.ckibana.configure.web.route.HttpRoute;
+import com.ly.ckibana.model.request.RequestContext;
+import com.ly.ckibana.model.response.IndexCheckResponse;
+import com.ly.ckibana.service.CkService;
+import com.ly.ckibana.util.JSONUtils;
+import com.ly.ckibana.util.ProxyUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import ru.yandex.clickhouse.BalancedClickhouseDataSource;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CheckHandler extends BaseHandler {
+
+    @Resource
+    private ProxyConfigLoader proxyConfigLoader;
+
+    @Resource
+    private CkService ckService;
+
+    @Override
+    public List<HttpRoute> routes() {
+        return List.of(
+                HttpRoute.newRoute().path("/check/{index}").methods(HttpMethod.GET)
+        );
+    }
+
+    @Override
+    public String doHandle(RequestContext context) {
+        Map<String, String> urlParams = context.getUrlParams();
+        String index = urlParams.get("index");
+        IndexCheckResponse response = new IndexCheckResponse();
+        try {
+            Pair<List<String>, String> tablesWithSql = ckService.queryTablesWithSql(context.getProxyConfig(), index);
+            BalancedClickhouseDataSource clickhouseDataSource = context.getProxyConfig().getCkDatasource();
+            response.setDatabaseUrls(clickhouseDataSource.getEnabledClickHouseUrls());
+            response.setIndex(index);
+            response.setDirectToEs(context.getProxyConfig().isDirectToEs(index));
+            List<String> whiteList = context.getProxyConfig().getKibanaItemProperty().getWhiteIndexList();
+            response.setInWhiteList(whiteList.stream().anyMatch(n -> n.equals(index)));
+            response.setHitTables(tablesWithSql.getLeft());
+            response.setWhiteList(whiteList);
+            response.setSql(tablesWithSql.getRight());
+            return JSONUtils.serialize(response);
+        } catch (Exception e) {
+            log.error("check index error :{}", index, e);
+            return ProxyUtils.getErrorResponse(e);
+        }
+    }
+}

--- a/src/main/java/com/ly/ckibana/model/response/IndexCheckResponse.java
+++ b/src/main/java/com/ly/ckibana/model/response/IndexCheckResponse.java
@@ -1,0 +1,21 @@
+package com.ly.ckibana.model.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 索引检查响应体
+ *
+ * @author kizuhiko
+ */
+@Data
+public class IndexCheckResponse {
+    private String index;
+    private List<String> databaseUrls;
+    private boolean directToEs;
+    private List<String> hitTables;
+    private boolean inWhiteList;
+    private List<String> whiteList;
+    private String sql;
+}

--- a/src/main/java/com/ly/ckibana/service/CkService.java
+++ b/src/main/java/com/ly/ckibana/service/CkService.java
@@ -144,6 +144,11 @@ public class CkService {
         return queryTablesWithCondition(proxyConfig, tableCondition);
     }
 
+    public Pair<List<String>, String> queryTablesWithSql(ProxyConfig proxyConfig, String tableName) throws Exception {
+        String tableCondition = String.format("name = '%s' ", tableName);
+        return queryTablesWithConditionWithSql(proxyConfig, tableCondition);
+    }
+
     public List<String> queryAllTables(ProxyConfig proxyConfig) throws Exception {
         return queryTablesWithCondition(proxyConfig, null);
     }
@@ -154,6 +159,11 @@ public class CkService {
     }
 
     private List<String> queryTablesWithCondition(ProxyConfig proxyConfig, String tableCondition) throws Exception {
+        Pair<List<String>, String> result = queryTablesWithConditionWithSql(proxyConfig, tableCondition);
+        return result.getLeft();
+    }
+
+    private Pair<List<String>, String> queryTablesWithConditionWithSql(ProxyConfig proxyConfig, String tableCondition) throws Exception {
         String ckDatabase = proxyConfig.getCkDatabase();
         if (ckDatabase == null) {
             throw new DataSourceEmptyException("clickhouse数据源为空，请检查配置proxy.ck");
@@ -163,7 +173,7 @@ public class CkService {
             sql = String.format("%s AND %s ", sql, tableCondition);
         }
         List<JSONObject> tables = queryData(proxyConfig, sql);
-        return tables.stream().map(each -> each.getString("name")).collect(Collectors.toList());
+        return Pair.of(tables.stream().map(each -> each.getString("name")).collect(Collectors.toList()), sql);
     }
 
     public Map<String, String> queryColumns(BalancedClickhouseDataSource clickhouseDataSource, String table) throws Exception {


### PR DESCRIPTION

## What is the problem your feature solves, or the need it fulfills?
增加check接口，用于排查ck表在index pattern中不显示的问题

## Describe the solution you'd like

通过接口`/check/表名`来访问，例如：/check/ops_test_all
返回结构如下：
```
{
    "index": "ops_test_all",
    "databaseUrls": [
        "jdbc:clickhouse://demo.test:80/ops"
    ],
    "directToEs": true,
    "hitTables": [],
    "inWhiteList": false,
    "whiteList": [
        "ops_test_all",
        "ops_test1_all"
    ],
    "sql": "SELECT name FROM system.tables WHERE database = 'ops'  AND name = 'ops_test_all'  "
}
```

## Describe alternatives you've considered
无

