### PR TITLE
fix: 修复8+版本的doc排序报错与hits total高低版本兼容

### DIFF
--- a/src/main/java/com/ly/ckibana/constants/Constants.java
+++ b/src/main/java/com/ly/ckibana/constants/Constants.java
@@ -45,6 +45,7 @@ public class Constants {
 
     public static final String KEY_NAME = "key";
 
+    public static final String DOC_TYPE = "_doc";
     /**
      * es查询参数关键字.
      */

--- a/src/main/java/com/ly/ckibana/model/response/Hits.java
+++ b/src/main/java/com/ly/ckibana/model/response/Hits.java
@@ -34,5 +34,5 @@ public class Hits {
     @JsonProperty("max_score")
     private long maxScore;
 
-    private long total;
+    private Object total;
 }

--- a/src/main/java/com/ly/ckibana/parser/MsearchParamParser.java
+++ b/src/main/java/com/ly/ckibana/parser/MsearchParamParser.java
@@ -74,7 +74,7 @@ public class MsearchParamParser extends ParamParser {
     public void checkTimeInRange(CkRequestContext ckRequestContext) {
         if (!isTimeInRange(ckRequestContext)) {
             throw new TimeNotInRangeException("查询时间跨度太大,目前支持最大查询区间为:"
-                    + DateUtils.formatDurationWords(proxyConfigLoader.getKibanaProperty().getProxy().getMaxTimeRange()));
+                                              + DateUtils.formatDurationWords(proxyConfigLoader.getKibanaProperty().getProxy().getMaxTimeRange()));
         }
     }
 
@@ -146,6 +146,9 @@ public class MsearchParamParser extends ParamParser {
                 each.keySet().forEach(orgField -> {
                     Map<String, String> columns = ckRequestContext.getColumns();
                     String ckSortFieldName = ParamConvertUtils.convertUiFieldToCkField(columns, orgField);
+                    if (Constants.DOC_TYPE.equals(ckSortFieldName)) {
+                        return;
+                    }
                     // 如果该字段在ck中不存在，且无ck_assembly_extension扩展字段，则不放到排序条件中
                     if (!columns.containsKey(ckSortFieldName) && !columns.containsKey(Constants.CK_EXTENSION)) {
                         return;

--- a/src/main/java/com/ly/ckibana/util/ParamConvertUtils.java
+++ b/src/main/java/com/ly/ckibana/util/ParamConvertUtils.java
@@ -15,6 +15,7 @@
  */
 package com.ly.ckibana.util;
 
+import com.ly.ckibana.constants.Constants;
 import com.ly.ckibana.model.exception.UnKnownFieldException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -41,7 +42,7 @@ public class ParamConvertUtils {
             result = StringUtils.trim(result);
         }
         // 未定义字段不支持查询
-        if (!columns.containsKey(result)) {
+        if (!columns.containsKey(result) && !Constants.DOC_TYPE.equals(orgField)) {
             throw new UnKnownFieldException(result);
         }
         return result;


### PR DESCRIPTION
# 问题描述
1. 在v8版本中，data view 查询时，对所有字段进行过滤，如果不存在则直接报错。这样导致的结果就是kibana不认识我们clickhouse底层存储的字段，有时候会默认传一个排序字段:_doc，导致我们接口直接报错，影响查询。
2. 对于高低版本，hits返回的total总数，结构有差异，可能有的是数字，有的是对象。
# 解决办法
1. 兼容_doc类型，不进行throws，且不进行排序拼接。
2. 兼容为Object


见 #36 