### PR TITLE
fix: Split out  user restclient, remove default header

### DIFF
--- a/src/main/java/com/ly/ckibana/configure/config/ProxyConfigLoader.java
+++ b/src/main/java/com/ly/ckibana/configure/config/ProxyConfigLoader.java
@@ -204,7 +204,7 @@ public class ProxyConfigLoader {
             try {
                 proxyConfig.getRestClient().close();
                 // create a new es client
-                proxyConfig.setRestClient(RestUtils.initEsResClient(this.kibanaProperty.getProxy().getEs()));
+                proxyConfig.setRestClient(RestUtils.initEsResClient(this.kibanaProperty.getProxy().getEs(), true));
             } catch (IOException e) {
                 log.error("close rest client error.", e);
             }

--- a/src/main/java/com/ly/ckibana/constants/Constants.java
+++ b/src/main/java/com/ly/ckibana/constants/Constants.java
@@ -226,4 +226,8 @@ public class Constants {
 
         public static final String BULK_INDEX_NO_TYPE_HEADER = "{ \"index\": { \"_index\" : \"%s\", \"_id\": \"%s\"}}";
     }
+
+    public static class Headers {
+        public static final String AUTHORIZATION = "authorization";
+    }
 }

--- a/src/main/java/com/ly/ckibana/handlers/BaseHandler.java
+++ b/src/main/java/com/ly/ckibana/handlers/BaseHandler.java
@@ -133,6 +133,10 @@ public abstract class BaseHandler implements CorsConfigurationSource {
         Map<String, Header> reqHeaders = HttpServletUtils.parseHttpRequestHeaders(request);
         Map<String, String> defaultHeaders = proxyConfig.getKibanaItemProperty().getEs().getHeaders();
         defaultHeaders.forEach((dhn, dhv) -> {
+            if (dhn.equalsIgnoreCase(Constants.Headers.AUTHORIZATION)) {
+                return;
+            }
+
             for (String headerName : reqHeaders.keySet()) {
                 if (headerName.equalsIgnoreCase(dhn)) {
                     reqHeaders.put(headerName, new BasicHeader(headerName, dhv));

--- a/src/main/java/com/ly/ckibana/model/request/ProxyConfig.java
+++ b/src/main/java/com/ly/ckibana/model/request/ProxyConfig.java
@@ -48,13 +48,16 @@ public class ProxyConfig {
 
     private RestClient restClient;
 
+    private RestClient userRestClient;
+
     private EsProxyClientConsumer esClientBuffer;
 
     private BalancedClickhouseDataSource ckDatasource;
 
     public ProxyConfig(KibanaItemProperty kibanaItemProperty) {
         this.kibanaItemProperty = kibanaItemProperty;
-        this.restClient = RestUtils.initEsResClient(kibanaItemProperty.getEs());
+        this.restClient = RestUtils.initEsResClient(kibanaItemProperty.getEs(), true);
+        this.userRestClient = RestUtils.initEsResClient(kibanaItemProperty.getEs(), false);
         this.esClientBuffer = new EsProxyClientConsumer();
         if (kibanaItemProperty.getCk() != null) {
             this.ckDatasource = CkService.initDatasource(kibanaItemProperty.getCk());

--- a/src/main/java/com/ly/ckibana/service/BlackSqlService.java
+++ b/src/main/java/com/ly/ckibana/service/BlackSqlService.java
@@ -61,11 +61,11 @@ public class BlackSqlService {
     }
 
     public String removeBlackSql(String id) {
-        return EsClientUtil.deleteSource(proxyConfigLoader.getMetadataRestClient(), Constants.ConfigFile.BLACK_LIST_INDEX_NAME, id);
+        return EsClientUtil.deleteSource(requestContext.getProxyConfig().getRestClient(), Constants.ConfigFile.BLACK_LIST_INDEX_NAME, id);
     }
 
     public String getList(int size) {
-        return EsClientUtil.search(proxyConfigLoader.getMetadataRestClient(), Constants.ConfigFile.BLACK_LIST_INDEX_NAME, String.format("{\"size\":%s}", size));
+        return EsClientUtil.search(requestContext.getProxyConfig().getRestClient(), Constants.ConfigFile.BLACK_LIST_INDEX_NAME, String.format("{\"size\":%s}", size));
     }
 
     public boolean isBlackSql(long range, String sql) {

--- a/src/main/java/com/ly/ckibana/service/EsClientUtil.java
+++ b/src/main/java/com/ly/ckibana/service/EsClientUtil.java
@@ -54,8 +54,11 @@ public class EsClientUtil {
 
     protected static final Header[] BASE_HEADER = new Header[]{new BasicHeader("Content-Type", "application/json")};
 
+    /**
+     * 不指定则采用用户restclient
+     */
     public static String doRequest(RequestContext context) throws Exception {
-        return doRequest(context.getProxyConfig().getRestClient(), context.getRequestInfo(), context.getHttpResponse());
+        return doRequest(context.getProxyConfig().getUserRestClient(), context.getRequestInfo(), context.getHttpResponse());
     }
 
     public static String doRequest(RestClient restClient, RequestContext.RequestInfo requestInfo, HttpServletResponse response) throws Exception {

--- a/src/main/java/com/ly/ckibana/util/RestUtils.java
+++ b/src/main/java/com/ly/ckibana/util/RestUtils.java
@@ -75,9 +75,9 @@ public class RestUtils {
     /**
      * 初始化es客户端.
      */
-    public static RestClient initEsResClient(EsProperty item) {
+    public static RestClient initEsResClient(EsProperty item, boolean mergeDefaultHeader) {
         Map<String, String> headersMap = new HashMap<>();
-        if (!CollectionUtils.isEmpty(item.getHeaders())) {
+        if (!CollectionUtils.isEmpty(item.getHeaders()) && mergeDefaultHeader) {
             headersMap.putAll(item.getHeaders());
         }
         return initEsRestClient(item.getHost(), headersMap);


### PR DESCRIPTION
# 描述
 1. 由用户发起的请求默认使用的ckibana的restclient，该restclient实例初始化时，默认加载了application.yml中的metadata-config的headers配置，例如：`Authorization`。
 2. kibana默认发过来的鉴权头名称是authorization，由于默认属性，所有请求都是用的该token，导致es认为是该配置的身份，而不是真实登陆的用户身份。

# 解决方式
将restclient的用途分离，默认不带headers。

#44 