### PR TITLE
fix: 解决获取当前代理indexPattern元数据时，使用默认配置的headers进行访问

### DIFF
--- a/src/main/java/com/ly/ckibana/handlers/AsyncSearchHandler.java
+++ b/src/main/java/com/ly/ckibana/handlers/AsyncSearchHandler.java
@@ -22,6 +22,7 @@ import com.ly.ckibana.constants.Constants;
 import com.ly.ckibana.model.compute.indexpattern.IndexPattern;
 import com.ly.ckibana.model.exception.FallbackToEsException;
 import com.ly.ckibana.model.exception.UiException;
+import com.ly.ckibana.model.property.MetadataConfigProperty;
 import com.ly.ckibana.model.property.QueryProperty;
 import com.ly.ckibana.model.request.CkRequestContext;
 import com.ly.ckibana.model.request.ProxyConfig;
@@ -57,6 +58,9 @@ public class AsyncSearchHandler extends BaseHandler {
     @Resource
     private MsearchParamParser msearchParamParser;
 
+    @Resource
+    private MetadataConfigProperty metadataConfigProperty;
+
     @Override
     public List<HttpRoute> routes() {
         return List.of(
@@ -76,7 +80,7 @@ public class AsyncSearchHandler extends BaseHandler {
         IndexPattern indexPattern = proxyConfig.buildIndexPattern(index);
         CkRequestContext ckRequestContext = new CkRequestContext(context.getClientIp(), indexPattern, paramParser.getMaxResultRow());
         Map<String, Map<String, String>> tableColumnsCache = new HashMap<>();
-        String timeField = EsClientUtil.getIndexPatternMeta(context.getProxyConfig().getRestClient()).get(index);
+        String timeField = EsClientUtil.getIndexPatternMeta(context.getProxyConfig().getRestClient(), metadataConfigProperty.getHeaders()).get(index);
         if (timeField == null) {
             log.warn("please set the date field of this index. [{}]", index);
             return JSONUtils.serialize(ProxyUtils.newKibanaException("请设置该索引的date字段"));

--- a/src/main/java/com/ly/ckibana/handlers/FieldCapsHandler.java
+++ b/src/main/java/com/ly/ckibana/handlers/FieldCapsHandler.java
@@ -19,6 +19,7 @@ import com.alibaba.fastjson2.JSONObject;
 import com.ly.ckibana.configure.web.route.HttpRoute;
 import com.ly.ckibana.model.compute.indexpattern.IndexPattern;
 import com.ly.ckibana.model.exception.FallbackToEsException;
+import com.ly.ckibana.model.property.MetadataConfigProperty;
 import com.ly.ckibana.model.request.ProxyConfig;
 import com.ly.ckibana.model.request.RequestContext;
 import com.ly.ckibana.parser.ParamParser;
@@ -36,6 +37,9 @@ public class FieldCapsHandler extends BaseHandler {
     
     @Resource
     private ParamParser paramParser;
+
+    @Resource
+    private MetadataConfigProperty metadataConfigProperty;
 
     @Override
     public List<HttpRoute> routes() {
@@ -62,7 +66,7 @@ public class FieldCapsHandler extends BaseHandler {
         JSONObject result = new JSONObject();
         ProxyConfig proxyConfig = context.getProxyConfig();
         IndexPattern indexPattern = proxyConfig.buildIndexPattern(context.getOriginalIndex(), index);
-        indexPattern.setTimeField(EsClientUtil.getIndexPatternMeta(context.getProxyConfig().getRestClient()).getOrDefault(index, null));
+        indexPattern.setTimeField(EsClientUtil.getIndexPatternMeta(context.getProxyConfig().getRestClient(), metadataConfigProperty.getHeaders()).getOrDefault(index, null));
         Map<String, JSONObject> fields = paramParser.queryIndexPatternFields(context, indexPattern, true);
         result.put("fields", fields);
         return JSONUtils.serialize(result);

--- a/src/main/java/com/ly/ckibana/parser/MsearchParamParser.java
+++ b/src/main/java/com/ly/ckibana/parser/MsearchParamParser.java
@@ -27,6 +27,7 @@ import com.ly.ckibana.model.exception.TimeNotInRangeException;
 import com.ly.ckibana.model.exception.UiException;
 import com.ly.ckibana.model.exception.UnKnowTimeFieldException;
 import com.ly.ckibana.model.property.KibanaItemProperty;
+import com.ly.ckibana.model.property.MetadataConfigProperty;
 import com.ly.ckibana.model.property.QueryProperty;
 import com.ly.ckibana.model.request.CkRequestContext;
 import com.ly.ckibana.model.request.CkRequestContext.SampleParam;
@@ -70,6 +71,9 @@ public class MsearchParamParser extends ParamParser {
 
     @Resource
     private ClauseStrategySelector clauseStrategySelector;
+
+    @Resource
+    private MetadataConfigProperty metadataConfigProperty;
 
     public void checkTimeInRange(CkRequestContext ckRequestContext) {
         if (!isTimeInRange(ckRequestContext)) {
@@ -206,7 +210,7 @@ public class MsearchParamParser extends ParamParser {
         String[] lines = context.getRequestInfo().getRequestBody().split(System.lineSeparator());
         QueryProperty queryProperty = proxyConfigLoader.getKibanaProperty().getQuery();
         ProxyConfig proxyConfig = context.getProxyConfig();
-        Map<String, String> indexPatternMeta = EsClientUtil.getIndexPatternMeta(context.getProxyConfig().getRestClient());
+        Map<String, String> indexPatternMeta = EsClientUtil.getIndexPatternMeta(context.getProxyConfig().getRestClient(), metadataConfigProperty.getHeaders());
         Map<String, Map<String, String>> tableColumnsCache = new HashMap<>();
         Map<String, Long> totalCountByQueryCache = new HashMap<>();
         for (int i = 0; i < lines.length; i++) {


### PR DESCRIPTION
# 问题描述
在内部查询index pattern时，需要从当前配置文件中的metadata-config的权限去获取。

#解决方式
传入metadata-config的headers到内部的restclient请求中。