### PR TITLE
Update mock-curl2nginx.sh

### DIFF
--- a/docker-compose/config/mock-curl2nginx.sh
+++ b/docker-compose/config/mock-curl2nginx.sh
@@ -13,5 +13,5 @@ while true; do
   if [ $((random_num % 10)) -eq 0 ]; then
       curl  "http://${HOST}/400"
   fi
-  # sleep $DELAY
+  sleep $DELAY
 done


### PR DESCRIPTION
curl之间增加等待间隔，避免把磁盘打爆。demo运行过程中，1分钟能产生200MB的数据，一会就把机器磁盘打满了